### PR TITLE
Refactor OutputService interface with unified renderOutput method

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,40 +42,19 @@ export async function runCli(services: CliServices): Promise<void> {
   const { outputService, tvShowService, configService, consoleOutput: output } = services;
   
   try {
-    // Get configuration options
+    // Get configuration options for fetching shows
     const showOptions = configService.getShowOptions();
-    const cliOptions = configService.getCliOptions();
-    
-    // Check if OutputService is initialized
-    if (!outputService.isInitialized()) {
-      output.error('Error: Output service not properly initialized');
-      return;
-    }
-    
-    // Display header
-    outputService.displayHeader();
     
     try {
       // Fetch TV shows
       const shows = await tvShowService.fetchShows(showOptions);
       
-      // Display debug info if enabled
-      if (cliOptions.debug) {
-        const networks = [...new Set(shows.map(show => show.network))].sort();
-        output.log('\nAvailable Networks:');
-        output.log(networks.join(', '));
-        output.log(`\nTotal Shows: ${shows.length}`);
-      }
-      
-      // Display shows
-      await outputService.displayShows(shows, cliOptions.groupByNetwork);
+      // Let the OutputService handle all rendering aspects
+      await outputService.renderOutput(shows);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       output.error(`Error fetching TV shows: ${errorMessage}`);
     }
-    
-    // Display footer
-    outputService.displayFooter();
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     output.error(`Unexpected error: ${errorMessage}`);

--- a/src/interfaces/outputService.ts
+++ b/src/interfaces/outputService.ts
@@ -2,28 +2,18 @@ import type { Show } from '../schemas/domain.js';
 
 /**
  * Interface for output services that display TV show information
+ * 
+ * This interface provides a single method for rendering TV show data.
+ * Implementations are responsible for handling all aspects of output
+ * including headers, footers, and formatting based on their injected
+ * configuration service.
  */
 export interface OutputService {
   /**
-   * Display TV shows to the user
+   * Execute the complete output workflow: display header, shows data, and footer
+   * Configuration options should be obtained from the injected ConfigService
+   * 
    * @param shows List of shows to display
-   * @param groupByNetwork Whether to group shows by network (default: true)
    */
-  displayShows(shows: Show[], groupByNetwork?: boolean): Promise<void>;
-  
-  /**
-   * Check if the service is properly initialized
-   * @returns True if initialized, false otherwise
-   */
-  isInitialized(): boolean;
-  
-  /**
-   * Display application header
-   */
-  displayHeader(): void;
-  
-  /**
-   * Display application footer
-   */
-  displayFooter(): void;
+  renderOutput(shows: Show[]): Promise<void>;
 }


### PR DESCRIPTION
## Overview
This PR addresses part of issue #69 by refactoring the OutputService interface to use a simplified approach with a unified `renderOutput` method. This change improves separation of concerns by making the OutputService responsible for the complete output workflow, rather than having the CLI coordinate multiple display methods.

## Changes
- Simplified the OutputService interface with a single `renderOutput` method
- Updated ConsoleOutputServiceImpl to implement the new interface
- Refactored the CLI to use the new interface
- Made display methods private in the implementation
- Added debug information display within the OutputService
- Updated tests to reflect the new interface

## Benefits
1. **Better Separation of Concerns**: The OutputService now handles the complete output workflow
2. **Simplified CLI**: The CLI no longer needs to coordinate multiple display methods
3. **Improved Testability**: Easier to test with a single entry point
4. **More Maintainable Code**: Clearer structure and responsibilities

## Testing
- All existing tests have been updated and pass
- The functionality remains the same, but with improved code organization

## Related Issues
Closes #69 (partially - this is the first step in the CLI refactoring)

## Screenshots
N/A - CLI application