### PR TITLE
chore: remove deprecated @types/pino dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@types/aws-lambda": "^8.10.149",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.0",
-        "@types/pino": "^7.0.4",
         "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^8.39.1",
         "@typescript-eslint/parser": "^8.39.1",
@@ -3740,16 +3739,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
-      }
-    },
-    "node_modules/@types/pino": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.4.tgz",
-      "integrity": "sha512-yKw1UbZOTe7vP1xMQT+oz3FexwgIpBTrM+AC62vWgAkNRULgLTJWfYX+H5/sKPm8VXFbIcXkC3VZPyuaNioZFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pino": "*"
       }
     },
     "node_modules/@types/retry": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/aws-lambda": "^8.10.149",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.0",
-    "@types/pino": "^7.0.4",
     "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.39.1",
     "@typescript-eslint/parser": "^8.39.1",


### PR DESCRIPTION
## 🧹 Remove Deprecated Dependency

This PR removes the deprecated  dependency as it's no longer needed with modern pino versions.

### 🔍 Background

The auto dependency PR wanted to bump  from 7.0.4 to 7.0.5, but investigation revealed that  is deprecated because pino (v9.7.0+) provides its own TypeScript definitions.

### 🔧 Changes Made

- **Removed**:  dependency entirely
- **Result**: Cleaner dependency tree without stub type definitions
- **Package count**: Reduced from 855 to 854 packages

### ✅ Quality Assurance

- **Tests**: All 594 tests passing with 95%+ coverage
- **TypeScript**: Full type safety maintained (pino provides native types)
- **Security**: Zero vulnerabilities found
- **Build**: All linting and compilation passes

### 📋 Benefits

- Eliminates deprecated dependency
- Reduces maintenance burden
- Uses native pino TypeScript definitions
- Better solution than updating to 7.0.5

This addresses the auto dependency PR by removing the need for  entirely rather than updating a deprecated package.