### PR TITLE
fix: prevent duplicate Slack messages in Lambda environment

### DIFF
--- a/src/tests/utils/errorHandling.test.ts
+++ b/src/tests/utils/errorHandling.test.ts
@@ -102,13 +102,22 @@ describe('errorHandling', () => {
 
   describe('isDirectExecution', () => {
     let originalNodeEnv: string | undefined;
+    let originalLambdaFunctionName: string | undefined;
 
     beforeEach(() => {
       originalNodeEnv = process.env.NODE_ENV;
+      originalLambdaFunctionName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+      // Clear Lambda env var for most tests
+      delete process.env.AWS_LAMBDA_FUNCTION_NAME;
     });
 
     afterEach(() => {
       process.env.NODE_ENV = originalNodeEnv;
+      if (originalLambdaFunctionName !== undefined) {
+        process.env.AWS_LAMBDA_FUNCTION_NAME = originalLambdaFunctionName;
+      } else {
+        delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+      }
     });
 
     it('should return false in test environment', () => {
@@ -124,6 +133,18 @@ describe('errorHandling', () => {
     it('should return true when NODE_ENV is undefined', () => {
       delete process.env.NODE_ENV;
       expect(isDirectExecution()).toBe(true);
+    });
+
+    it('should return false in Lambda environment', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
+      expect(isDirectExecution()).toBe(false);
+    });
+
+    it('should return false in Lambda environment even with dev NODE_ENV', () => {
+      process.env.NODE_ENV = 'dev';
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'WhatsOnTvDev-DailyShowUpdates';
+      expect(isDirectExecution()).toBe(false);
     });
   });
 

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -58,8 +58,11 @@ export function handleMainError(error: unknown, consoleOutput: ConsoleOutput): v
  * @returns True if the file should execute its main function
  */
 export function isDirectExecution(): boolean {
-  // Don't run main() when in a test environment
-  return process.env.NODE_ENV !== 'test';
+  // Don't run main() when in a test environment or Lambda
+  // Lambda sets AWS_LAMBDA_FUNCTION_NAME, so we can detect it
+  const isTest = process.env.NODE_ENV === 'test';
+  const isLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined;
+  return !isTest && !isLambda;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixed `isDirectExecution()` to detect Lambda environment by checking `AWS_LAMBDA_FUNCTION_NAME` env var
- Prevents module-level `runMain()` in `slackCli.ts` from executing when imported by Lambda handler

## Root Cause

When the Lambda handler imported `slackCli.ts`, the module-level `runMain()` call was executing because `isDirectExecution()` only checked for test environment (`NODE_ENV === 'test'`). In Lambda, `NODE_ENV` is set to 'dev', so it returned `true`, causing the app to run twice:
1. Once from the module-level `runMain()` in `slackCli.ts`
2. Once from the Lambda handler's explicit `app.run()` call

## Fix

Updated `isDirectExecution()` to also check for `AWS_LAMBDA_FUNCTION_NAME`, which AWS sets automatically in Lambda environments.

## Test Plan

- [x] Added unit tests for Lambda environment detection
- [x] All 601 tests passing
- [x] Deployed to dev environment
- [x] Invoked Lambda and verified single message set in Slack (was: 2 headers + 2 content, now: 1 header + 1 content)