### PR TITLE
refactor: code duplication cleanup and type consolidation

### DIFF
--- a/infrastructure/whatsontv-stack.ts
+++ b/infrastructure/whatsontv-stack.ts
@@ -12,6 +12,16 @@ import { Construct } from 'constructs';
 import * as fs from 'fs';
 import * as path from 'path';
 
+/**
+ * CDK deployment configuration (read from config.json at deploy time)
+ *
+ * This is intentionally separate from src/types/configTypes.ts AppConfig:
+ * - This type: Minimal config needed for CDK infrastructure deployment
+ * - configTypes.ts: Full runtime application config (filters, timing, etc.)
+ *
+ * The CDK only needs Slack credentials to pass to Lambda environment variables.
+ * Runtime filtering/display options are read directly by the app at runtime.
+ */
 interface AppConfig {
   slack: {
     token: string;

--- a/src/implementations/console/textShowFormatterImpl.ts
+++ b/src/implementations/console/textShowFormatterImpl.ts
@@ -99,7 +99,12 @@ export class TextShowFormatterImpl extends BaseShowFormatterImpl<string> {
   }
 
   /**
-   * Format episode range for multiple episodes
+   * Format episode range for multiple episodes (simple first-to-last range)
+   *
+   * Note: This is a simplified version that shows just the first and last episode
+   * (e.g., "S01E01-05"). For more comprehensive formatting that handles gaps
+   * (e.g., "S01E01-03, S01E05"), see formatEpisodeRanges() in showUtils.ts.
+   *
    * @param shows Multiple episodes of the same show
    * @returns Formatted episode range
    */

--- a/src/implementations/fetchHttpClientImpl.ts
+++ b/src/implementations/fetchHttpClientImpl.ts
@@ -17,15 +17,6 @@ import type { LoggerService } from '../interfaces/loggerService.js';
 import { z } from 'zod';
 
 /**
- * Request options for HTTP client
- */
-export interface RequestOptions {
-  headers?: Record<string, string>;
-  timeout?: number;
-  query?: Record<string, string | number | boolean>;
-}
-
-/**
  * Options for configuring the KyHttpClient
  */
 export interface KyHttpClientOptions {

--- a/src/prototypes/slackMessagePrototypes.ts
+++ b/src/prototypes/slackMessagePrototypes.ts
@@ -13,7 +13,10 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Types for Slack message components
+// Local types for Slack message components
+// Note: These are intentionally separate from src/interfaces/slackClient.ts types.
+// Prototypes need flexible generic types for experimentation (e.g., 'actions' blocks),
+// while production code uses strictly typed unions for type safety.
 interface SlackBlock {
   type: string;
   [key: string]: unknown;

--- a/src/schemas/http.ts
+++ b/src/schemas/http.ts
@@ -1,7 +1,11 @@
 /**
  * HTTP Schema Definitions
- * 
- * This file contains schema definitions for HTTP requests and responses
+ *
+ * This file contains Zod schema definitions for runtime validation of HTTP
+ * requests and responses. These schemas are primarily used for testing.
+ *
+ * Note: For the canonical TypeScript interface types, see:
+ * - src/interfaces/httpClient.ts (RequestOptions, HttpResponse<T>)
  */
 
 import { z } from 'zod';
@@ -26,11 +30,20 @@ export const httpResponseSchema = z.object({
 });
 
 /**
- * Request options type
+ * Schema-inferred request options type (for validation only)
+ * Note: Use RequestOptions from httpClient.ts for application code
  */
-export type RequestOptions = z.infer<typeof requestOptionsSchema>;
+export type RequestOptionsSchema = z.infer<typeof requestOptionsSchema>;
 
 /**
- * HTTP response type
+ * Schema-inferred HTTP response type (for validation only)
+ * Note: Use HttpResponse<T> from httpClient.ts for application code
  */
-export type HttpResponse = z.infer<typeof httpResponseSchema>;
+export type HttpResponseSchema = z.infer<typeof httpResponseSchema>;
+
+// Deprecated type aliases for backwards compatibility
+// TODO: Remove these in a future version
+/** @deprecated Use RequestOptionsSchema instead, or RequestOptions from httpClient.ts */
+export type RequestOptions = RequestOptionsSchema;
+/** @deprecated Use HttpResponseSchema instead, or HttpResponse<T> from httpClient.ts */
+export type HttpResponse = HttpResponseSchema;

--- a/src/tests/utils/showUtils.test.ts
+++ b/src/tests/utils/showUtils.test.ts
@@ -4,10 +4,9 @@
 import { jest, describe, it, expect } from '@jest/globals';
 
 // Import the functions to test
-import { 
-  groupShowsByNetwork, 
-  sortShowsByTime, 
-  formatTime,
+import {
+  groupShowsByNetwork,
+  sortShowsByTime,
   filterByType,
   filterByNetwork,
   filterByGenre,
@@ -162,33 +161,6 @@ describe('ShowUtils', () => {
       expect(result[0].name).toBe('A Show');
       expect(result[1].name).toBe('B Show');
       expect(result[2].name).toBe('C Show');
-    });
-  });
-  
-  describe('formatTime', () => {
-    it('formats time with AM/PM', () => {
-      // Test various time formats
-      expect(formatTime('08:00')).toBe('8:00 AM');
-      expect(formatTime('12:00')).toBe('12:00 PM');
-      expect(formatTime('13:30')).toBe('1:30 PM');
-      expect(formatTime('00:00')).toBe('12:00 AM');
-      expect(formatTime('23:59')).toBe('11:59 PM');
-    });
-    
-    it('handles null or empty time strings', () => {
-      expect(formatTime(null)).toBe('N/A');
-      expect(formatTime('')).toBe('N/A');
-    });
-    
-    it('handles invalid time formats', () => {
-      expect(formatTime('not a time')).toBe('N/A');
-      // The current implementation doesn't validate hour/minute ranges
-      // so these actually return formatted times
-      const formattedTime25 = formatTime('25:00');
-      expect(formattedTime25).toBe('1:00 PM');
-      
-      const formattedTime12_60 = formatTime('12:60');
-      expect(formattedTime12_60).toBe('12:60 PM');
     });
   });
   

--- a/src/tests/utils/stringUtils.test.ts
+++ b/src/tests/utils/stringUtils.test.ts
@@ -2,6 +2,9 @@
  * Tests for string utility functions
  */
 import {
+  isEmptyString,
+  hasContent,
+  isEmptyArray,
   getStringOrDefault,
   getStringValue,
   padString,
@@ -12,6 +15,93 @@ import {
 } from '../../utils/stringUtils.js';
 
 describe('stringUtils', () => {
+  describe('isEmptyString', () => {
+    it('should return true for null', () => {
+      expect(isEmptyString(null)).toBe(true);
+    });
+
+    it('should return true for undefined', () => {
+      expect(isEmptyString(undefined)).toBe(true);
+    });
+
+    it('should return true for empty string', () => {
+      expect(isEmptyString('')).toBe(true);
+    });
+
+    it('should return false for non-empty string', () => {
+      expect(isEmptyString('test')).toBe(false);
+    });
+
+    it('should return false for whitespace without trim', () => {
+      expect(isEmptyString('   ')).toBe(false);
+    });
+
+    it('should return true for whitespace with trim', () => {
+      expect(isEmptyString('   ', true)).toBe(true);
+    });
+
+    it('should return false for string with content and trim', () => {
+      expect(isEmptyString('  test  ', true)).toBe(false);
+    });
+  });
+
+  describe('hasContent', () => {
+    it('should return false for null', () => {
+      expect(hasContent(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(hasContent(undefined)).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(hasContent('')).toBe(false);
+    });
+
+    it('should return true for non-empty string', () => {
+      expect(hasContent('test')).toBe(true);
+    });
+
+    it('should return true for whitespace (does not trim)', () => {
+      expect(hasContent('   ')).toBe(true);
+    });
+
+    it('should narrow type correctly', () => {
+      const value: string | null = 'test';
+      if (hasContent(value)) {
+        // TypeScript should know value is string here
+        expect(value.toUpperCase()).toBe('TEST');
+      }
+    });
+  });
+
+  describe('isEmptyArray', () => {
+    it('should return true for null', () => {
+      expect(isEmptyArray(null)).toBe(true);
+    });
+
+    it('should return true for undefined', () => {
+      expect(isEmptyArray(undefined)).toBe(true);
+    });
+
+    it('should return true for empty array', () => {
+      expect(isEmptyArray([])).toBe(true);
+    });
+
+    it('should return false for array with elements', () => {
+      expect(isEmptyArray([1, 2, 3])).toBe(false);
+    });
+
+    it('should return false for array with single element', () => {
+      expect(isEmptyArray(['test'])).toBe(false);
+    });
+
+    it('should work with different types', () => {
+      expect(isEmptyArray([{ key: 'value' }])).toBe(false);
+      expect(isEmptyArray([null])).toBe(false); // Array with null element is not empty
+    });
+  });
+
   describe('getStringOrDefault', () => {
     it('should return the input value if it is valid', () => {
       expect(getStringOrDefault('test', 'default')).toBe('test');

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,0 +1,43 @@
+# Type Organization
+
+This document explains the type/interface/schema organization in the codebase.
+
+## Directory Structure
+
+### `src/types/` - Configuration & CLI Types
+TypeScript type definitions for application configuration:
+- `configTypes.ts` - AppConfig, SlackConfig, CliOptions
+- `tvShowOptions.ts` - ShowOptions for filtering
+- `cliArgs.ts` - CLI argument types
+
+### `src/schemas/` - Zod Schemas & Domain Types
+Runtime validation schemas and domain model types:
+- `domain.ts` - Core domain types (Show, NetworkGroups)
+- `tvmaze.ts` - TVMaze API response schemas with transformations
+- `common.ts` - Shared schema utilities
+- `http.ts` - HTTP request/response validation schemas
+
+### `src/interfaces/` - Service Contracts
+Abstract service interfaces for dependency injection:
+- `httpClient.ts` - HTTP client contract + HttpResponse<T>, RequestOptions
+- `configService.ts` - Configuration service contract
+- `outputService.ts` - Output rendering contract
+- `showFormatter.ts` - Show formatting contract
+- `slackClient.ts` - Slack API contract + SlackMessagePayload, SlackBlock types
+
+## Key Principles
+
+1. **Interfaces define contracts** - Service interfaces in `interfaces/` define what implementations must provide
+
+2. **Schemas validate at boundaries** - Zod schemas in `schemas/` validate external data (API responses)
+
+3. **Types configure behavior** - Types in `types/` define configuration and options
+
+4. **Domain types are canonical** - `schemas/domain.ts` exports the canonical `Show` type used throughout
+
+## Import Guidelines
+
+- Import service interfaces from `interfaces/`
+- Import domain types (Show, NetworkGroups) from `schemas/domain.ts`
+- Import config types from `types/configTypes.ts`
+- Import validation schemas from `schemas/` for runtime validation

--- a/src/types/configTypes.ts
+++ b/src/types/configTypes.ts
@@ -14,7 +14,13 @@ export interface SlackConfig {
 }
 
 /**
- * Application configuration structure
+ * Application runtime configuration structure
+ *
+ * This is intentionally separate from infrastructure/whatsontv-stack.ts AppConfig:
+ * - This type: Full runtime config with filters, timing, display options
+ * - whatsontv-stack.ts: Minimal CDK deployment config (just Slack credentials)
+ *
+ * This config is read at runtime from config.json (or config.lambda.json in Lambda).
  */
 export interface AppConfig {
   country: string;

--- a/src/utils/showUtils.ts
+++ b/src/utils/showUtils.ts
@@ -1,13 +1,8 @@
 /**
  * Utility functions for working with TV shows
  */
-import type { Show } from '../schemas/domain.js';
+import type { Show, NetworkGroups } from '../schemas/domain.js';
 import { convertTimeToMinutes } from './dateUtils.js';
-
-/**
- * Type for grouping shows by network
- */
-export type NetworkGroups = Record<string, Show[]>;
 
 /**
  * Get the network name from a show with fallback to "Unknown Network"
@@ -104,33 +99,6 @@ export function sortShowsByTime(shows: Show[]): Show[] {
     }
     return a.name.localeCompare(b.name);
   });
-}
-
-/**
- * Format time string to 12-hour format
- * @param time - Time string in HH:MM format
- * @returns Formatted time string
- */
-export function formatTime(time: string | null): string {
-  if (time === null || time === '') {
-    return 'N/A';
-  }
-  
-  // Parse hours and minutes
-  const [hoursStr, minutesStr] = time.split(':');
-  
-  if (hoursStr === undefined || minutesStr === undefined) {
-    return 'N/A';
-  }
-  
-  const hours = parseInt(hoursStr, 10);
-  const minutes = minutesStr;
-  
-  // Convert to 12-hour format
-  const period = hours >= 12 ? 'PM' : 'AM';
-  const hours12 = hours % 12 || 12; // Convert 0 to 12 for 12 AM
-  
-  return `${hours12}:${minutes} ${period}`;
 }
 
 /**

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -3,13 +3,45 @@
  */
 
 /**
+ * Check if a string is null, undefined, or empty
+ * @param value - The value to check
+ * @param trim - Whether to trim whitespace before checking (default: false)
+ * @returns True if the value is null, undefined, or empty string
+ */
+export function isEmptyString(value: string | null | undefined, trim = false): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  return trim ? value.trim() === '' : value === '';
+}
+
+/**
+ * Check if a string has content (type guard that narrows to string)
+ * @param value - The value to check
+ * @returns True if value is a non-empty string
+ */
+export function hasContent(value: string | null | undefined): value is string {
+  return value !== null && value !== undefined && value !== '';
+}
+
+/**
+ * Check if an array is null, undefined, or empty
+ * @param arr - The array to check
+ * @returns True if the array is null, undefined, or has no elements
+ */
+export function isEmptyArray<T>(arr: T[] | null | undefined): boolean {
+  return arr === null || arr === undefined || arr.length === 0;
+}
+
+/**
  * Get a string value or a default if empty/null/undefined
  * @param value - The string to check
  * @param defaultValue - The default value to use
  * @returns The input value if valid, or the default value
  */
 export function getStringOrDefault(value: string | null | undefined, defaultValue: string): string {
-  if (value === undefined || value === null || value.trim() === '') {
+  // Check for null/undefined/empty first, then check trimmed
+  if (value === null || value === undefined || value.trim() === '') {
     return defaultValue;
   }
   return value.trim();
@@ -23,13 +55,10 @@ export function getStringOrDefault(value: string | null | undefined, defaultValu
  * @returns The input value if valid, or the default value
  */
 export function getStringValue(
-  value: string | null | undefined, 
+  value: string | null | undefined,
   defaultValue: string = ''
 ): string {
-  if (value === null || value === undefined || value === '') {
-    return defaultValue;
-  }
-  return value;
+  return hasContent(value) ? value : defaultValue;
 }
 
 /**
@@ -82,17 +111,17 @@ export function truncateString(
  * @returns Formatted string
  */
 export function formatListWithSeparator(items: string[], separator: string = ', '): string {
-  if (items === undefined || items === null || items.length === 0) {
+  if (isEmptyArray(items)) {
     return '';
   }
-  
+
   // Filter out empty items
-  const filteredItems = items.filter(item => item !== null && item !== undefined && item !== '');
-  
-  if (filteredItems.length === 0) {
+  const filteredItems = items.filter(item => !isEmptyString(item));
+
+  if (isEmptyArray(filteredItems)) {
     return '';
   }
-  
+
   return filteredItems.join(separator);
 }
 


### PR DESCRIPTION
## Summary

This PR addresses the code duplication audit findings from issue #244, cleaning up duplicate types, dead code, and adding documentation for type organization.

### Changes

**Type Cleanup:**
- Remove duplicate `NetworkGroups` type from `showUtils.ts` (Closes #245)
- Remove unused `RequestOptions` from `fetchHttpClientImpl.ts` (Closes #248)
- Add deprecated aliases and clarify `HttpResponse` types (Closes #249)

**Dead Code Removal:**
- Remove dead `formatTime` function from `showUtils.ts` (Closes #247)

**New Utilities:**
- Create `isEmptyString(value, trim?)` utility with 7 tests (Closes #251)
- Create `isEmptyArray(arr)` utility with 6 tests (Closes #252)
- Create `hasContent(value)` type guard with 6 tests (code review addition)
- Refactor existing functions to use these utilities

**Documentation:**
- Add clarifying comment to `SlackMessagePayload` in prototypes (Closes #246)
- Add AppConfig separation documentation comments (Closes #250)
- Document episode range formatting differences (Closes #253)
- Add `src/types/README.md` for type organization docs (Closes #254)

### Code Review Fixes Applied
- Replaced `as string` type assertions with proper type guard (`hasContent()`)
- Added 6 additional tests for the new type guard

## Test Plan

- [x] All 619 tests passing (up from 601)
- [x] Build passes
- [x] Lint passes
- [x] No breaking changes - all changes are internal refactoring