### PR TITLE
test: improve test coverage for lambdaContainer and pino logger

### DIFF
--- a/src/tests/implementations/pino/pinoLoggerServiceImpl.test.ts
+++ b/src/tests/implementations/pino/pinoLoggerServiceImpl.test.ts
@@ -85,9 +85,29 @@ describe('PinoLoggerServiceImpl', () => {
     it('should allow child logger to create its own child', () => {
       const childLogger = loggerService.child({ module: 'test' });
       const grandChildLogger = childLogger.child({ operation: 'fetch' });
-      
+
       expect(grandChildLogger).toBeDefined();
       expect(typeof grandChildLogger.info).toBe('function');
+    });
+
+    it('should allow child logger to log with string-only argument', () => {
+      const childLogger = loggerService.child({ module: 'test' });
+
+      // Test all logging methods with string-only arguments
+      expect(() => childLogger.info('string-only info')).not.toThrow();
+      expect(() => childLogger.warn('string-only warn')).not.toThrow();
+      expect(() => childLogger.error('string-only error')).not.toThrow();
+      expect(() => childLogger.debug('string-only debug')).not.toThrow();
+    });
+
+    it('should allow child logger to log with context and message', () => {
+      const childLogger = loggerService.child({ module: 'test' });
+
+      // Test all logging methods with context object and message
+      expect(() => childLogger.info({ key: 'value' }, 'info with context')).not.toThrow();
+      expect(() => childLogger.warn({ key: 'value' }, 'warn with context')).not.toThrow();
+      expect(() => childLogger.error({ key: 'value' }, 'error with context')).not.toThrow();
+      expect(() => childLogger.debug({ key: 'value' }, 'debug with context')).not.toThrow();
     });
   });
 

--- a/src/tests/lambdaContainer.test.ts
+++ b/src/tests/lambdaContainer.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for Lambda container initialization
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { container } from 'tsyringe';
+
+describe('lambdaContainer', () => {
+  let originalAppConfig: string | undefined;
+
+  beforeEach(() => {
+    // Save and set APP_CONFIG for Lambda config service
+    originalAppConfig = process.env.APP_CONFIG;
+    process.env.APP_CONFIG = JSON.stringify({ country: 'US' });
+
+    // Clear the container before each test
+    container.clearInstances();
+  });
+
+  afterEach(() => {
+    // Restore original env var
+    if (originalAppConfig === undefined) {
+      delete process.env.APP_CONFIG;
+    } else {
+      process.env.APP_CONFIG = originalAppConfig;
+    }
+
+    // Clear container after test
+    container.clearInstances();
+  });
+
+  it('initializes all Lambda dependencies without error', async () => {
+    // Dynamic import to avoid side effects at module load time
+    const { initializeLambdaContainer } = await import('../lambdaContainer.js');
+
+    expect(() => initializeLambdaContainer()).not.toThrow();
+  });
+
+  it('registers TvShowService', async () => {
+    const { initializeLambdaContainer, container: lambdaContainer } =
+      await import('../lambdaContainer.js');
+
+    initializeLambdaContainer();
+
+    const tvShowService = lambdaContainer.resolve('TvShowService');
+    expect(tvShowService).toBeDefined();
+  });
+
+  it('registers ConfigService as LambdaConfigServiceImpl', async () => {
+    const { initializeLambdaContainer, container: lambdaContainer } =
+      await import('../lambdaContainer.js');
+
+    initializeLambdaContainer();
+
+    const configService = lambdaContainer.resolve('ConfigService');
+    expect(configService).toBeDefined();
+    expect(configService.getShowOptions()).toHaveProperty('country');
+  });
+
+  it('registers SlackClient', async () => {
+    const { initializeLambdaContainer, container: lambdaContainer } =
+      await import('../lambdaContainer.js');
+
+    initializeLambdaContainer();
+
+    const slackClient = lambdaContainer.resolve('SlackClient');
+    expect(slackClient).toBeDefined();
+  });
+
+  it('registers platform type as lambda', async () => {
+    const { initializeLambdaContainer, container: lambdaContainer } =
+      await import('../lambdaContainer.js');
+
+    initializeLambdaContainer();
+
+    const platformType = lambdaContainer.resolve('PlatformType');
+    expect(platformType).toBe('lambda');
+  });
+});


### PR DESCRIPTION
## Summary

Adds tests to improve overall test coverage from 94% to 96%.

## Changes

- **lambdaContainer.ts**: 0% → 72% coverage
  - Tests that container initializes without errors
  - Tests that key services are registered (TvShowService, ConfigService, SlackClient)
  - Tests platform type is set to 'lambda'

- **pinoLoggerServiceImpl.ts**: 80% → 100% coverage
  - Tests child logger's string-only method overloads
  - Tests child logger's context + message overloads

## Test plan

- [x] All 641 tests pass
- [x] Coverage thresholds met (75% minimum)