### PR TITLE
chore(deps): update npm dependencies and fix deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@slack/web-api": "7.15.0",
+        "@slack/web-api": "7.15.1",
         "chalk": "^5.6.2",
         "ky": "^2.0.0",
         "pino": "^10.1.0",
@@ -2105,16 +2105,16 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
-      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.1.tgz",
+      "integrity": "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==",
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.1",
         "@slack/types": "^2.20.1",
         "@types/node": ">=18",
         "@types/retry": "0.12.0",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "eventemitter3": "^5.0.1",
         "form-data": "^4.0.4",
         "is-electron": "2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,9 +66,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.14.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.14.0.tgz",
-      "integrity": "sha512-prx2sbFfKrVf3NNXMOmWq6lsIBeWQDIqMTILLAddGiidn9j7OnLUubknWpJlLozMveTvQELdI++nUwq6jwCm9g==",
+      "version": "53.17.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.17.0.tgz",
+      "integrity": "sha512-JB9L4JCbZeYbMJPs7OKV+7YaxKwk4i2tlI5PCSfCzk4DJvprhCO2TYcqbqo3Y1YWZyyY/SEPLWdorG7b88fUSA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -621,9 +621,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -641,9 +641,9 @@
       "optional": true
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1236,25 +1236,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1361,9 +1375,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1959,9 +1973,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "version": "0.41.4",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
+      "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2058,9 +2072,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.1.tgz",
-      "integrity": "sha512-oDDGPn/4jD3viZLphixgu1jwT0bqIqP25FNXC5OkWrUqHZOF4wATtSyVzluOt4DqcMqSoKMClyhUllKSxpQCng==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2291,17 +2305,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2314,22 +2328,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2345,14 +2359,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2367,14 +2381,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2385,9 +2399,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2402,15 +2416,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2427,9 +2441,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2441,16 +2455,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2469,16 +2483,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2493,13 +2507,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3103,9 +3117,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1118.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.0.tgz",
-      "integrity": "sha512-Tfd865GRewDTXIbTVtix/l+v8t3rZENvdHcQQZS2wXYVXfHzljULFXe9JKkgZUNDPB1zo9tSBUu8jjiHRm7nWg==",
+      "version": "2.1118.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.4.tgz",
+      "integrity": "sha512-wJfRQdvb+FJ2cni059mYdmjhfwhMskP+PAB59BL9jhon+jYtjy8X3pbj3uzHgAOJwNhh6jGkP8xq36Cffccbbw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3116,9 +3130,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.248.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
-      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
+      "version": "2.250.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.250.0.tgz",
+      "integrity": "sha512-8U8/S9VcmKSc3MHZWiB7P0IecgXoohI8Ya3dgtZMgbzC4mB+MEQmsYBeNgm4vzGQdRos8HjQLnFX1IBlZh7jQA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -3546,9 +3560,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -3699,9 +3713,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
-      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3881,9 +3895,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -4304,9 +4318,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.335",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
-      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4549,18 +4563,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4696,9 +4710,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4805,9 +4819,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.2.tgz",
-      "integrity": "sha512-BTcT1zr1iTbmJtVlcesISwnXzh+9uhf9LEOr+RRNf4kR8xA0HQTPft4oiyOCzCOGKkpSJxjR8ZYF6H7VPyplyw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
+      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -4818,10 +4832,10 @@
         "globals": "^17.4.0",
         "jsx-ast-utils-x": "^0.1.0",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "scslre": "^0.3.0",
         "semver": "^7.7.4",
-        "ts-api-utils": "^2.4.0",
+        "ts-api-utils": "^2.5.0",
         "typescript": ">=5"
       },
       "peerDependencies": {
@@ -5180,9 +5194,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5413,9 +5427,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5457,9 +5471,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5607,9 +5621,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5814,9 +5828,9 @@
       }
     },
     "node_modules/is-builtin-module/node_modules/builtin-modules": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
-      "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.1.0.tgz",
+      "integrity": "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7485,9 +7499,9 @@
       }
     },
     "node_modules/ky": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-2.0.0.tgz",
-      "integrity": "sha512-KzI4Vz5AbZFAUFYGx28PCSfFWUo6/qj9Br/P6KRwDieE1xfdz0tIONepJcLw/1xLocN13GgvfJGasa+pfSkbHg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-2.0.1.tgz",
+      "integrity": "sha512-HJPEjEpQPZQ5M3G5eu90/LWZDwysCnvqcfbLvq9FUvfizBZRi58WEixswyyI32LOLcFQd43w7kcfgkCPFxDt/Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -7721,9 +7735,9 @@
       "license": "MIT"
     },
     "node_modules/nock": {
-      "version": "14.0.12",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.12.tgz",
-      "integrity": "sha512-kZM3bHV0KzhHH6E2eRszHyML/w87AUzLBwupNTHohtYWP9fZYgUPmCbSKq6ITfEEmHqN4/p0MscvUipT4P5Qsg==",
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.13.tgz",
+      "integrity": "sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8144,9 +8158,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -8595,15 +8609,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -9972,9 +9986,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/szeller/whatsontv.git"
   },
   "dependencies": {
-    "@slack/web-api": "7.15.0",
+    "@slack/web-api": "7.15.1",
     "chalk": "^5.6.2",
     "ky": "^2.0.0",
     "pino": "^10.1.0",

--- a/src/implementations/fetchHttpClientImpl.ts
+++ b/src/implementations/fetchHttpClientImpl.ts
@@ -59,7 +59,7 @@ export class FetchHttpClientImpl implements HttpClient {
       info: () => { /* noop */ },
       debug: () => { /* noop */ },
       child: () => this.logger
-    } as LoggerService;
+    };
     
     // Create a configured instance of ky
     this.kyInstance = ky.create({

--- a/src/implementations/slack/slackClientImpl.ts
+++ b/src/implementations/slack/slackClientImpl.ts
@@ -34,7 +34,7 @@ export class SlackClientImpl implements SlackClient {
       info: () => { /* noop */ },
       debug: () => { /* noop */ },
       child: () => this.logger
-    } as LoggerService;
+    };
     
     // Use the factory if provided, otherwise create a new WebClient directly
     this._client = this.webClientFactory

--- a/src/implementations/slack/slackOutputServiceImpl.ts
+++ b/src/implementations/slack/slackOutputServiceImpl.ts
@@ -32,7 +32,7 @@ export class SlackOutputServiceImpl extends BaseOutputServiceImpl<SlackBlock> {
       info: () => { /* noop */ },
       debug: () => { /* noop */ },
       child: () => this.logger
-    } as LoggerService;
+    };
   }
 
   /**

--- a/src/implementations/tvMazeServiceImpl.ts
+++ b/src/implementations/tvMazeServiceImpl.ts
@@ -34,7 +34,7 @@ export class TvMazeServiceImpl implements TvShowService {
       info: () => { /* noop */ },
       debug: () => { /* noop */ },
       child: () => this.logger
-    } as LoggerService;
+    };
   }
 
   /**

--- a/src/tests/cli/cliBase.test.ts
+++ b/src/tests/cli/cliBase.test.ts
@@ -7,8 +7,6 @@ import {
   it,
   expect
 } from '@jest/globals';
-import type { OutputService } from '../../interfaces/outputService.js';
-import type { TvShowService } from '../../interfaces/tvShowService.js';
 import type { ConfigService } from '../../interfaces/configService.js';
 import type { ProcessOutput } from '../../interfaces/processOutput.js';
 import type { Show } from '../../schemas/domain.js';
@@ -93,10 +91,10 @@ describe('CLI', () => {
     
     // Create CLI application with mock services
     cliApp = new BaseCliApplication(
-      mockTvShowService as unknown as TvShowService,
+      mockTvShowService,
       mockConfigService as unknown as ConfigService,
       mockProcessOutput as unknown as ProcessOutput,
-      mockOutputService as unknown as OutputService
+      mockOutputService
     );
   });
 

--- a/src/tests/fixtures/helpers/slackClientFixture.ts
+++ b/src/tests/fixtures/helpers/slackClientFixture.ts
@@ -15,7 +15,7 @@ export const SlackClientFixture = {
   createMockClient(): jest.Mocked<SlackClient> {
     return {
       sendMessage: jest.fn<() => Promise<void>>().mockResolvedValue()
-    } as jest.Mocked<SlackClient>;
+    };
   },
 
   /**

--- a/src/tests/helpers/yargsHelper.test.ts
+++ b/src/tests/helpers/yargsHelper.test.ts
@@ -49,10 +49,10 @@ describe('yargsHelper', () => {
 
       test('throws error for invalid command argument', () => {
         expect(() => {
-          mockYargsInstance.command(123 as unknown);
+          mockYargsInstance.command(123);
         }).toThrow(TypeError);
         expect(() => {
-          mockYargsInstance.command(123 as unknown);
+          mockYargsInstance.command(123);
         }).toThrow('Invalid command argument');
       });
     });
@@ -116,10 +116,10 @@ describe('yargsHelper', () => {
 
       test('throws error for non-array arguments', () => {
         expect(() => {
-          mockYargsInstance.parse(123 as unknown);
+          mockYargsInstance.parse(123);
         }).toThrow(TypeError);
         expect(() => {
-          mockYargsInstance.parse(123 as unknown);
+          mockYargsInstance.parse(123);
         }).toThrow('Parse expects string array argument');
       });
     });
@@ -140,10 +140,10 @@ describe('yargsHelper', () => {
 
       test('throws error for invalid options argument', () => {
         expect(() => {
-          mockYargsInstance.options('invalid' as unknown);
+          mockYargsInstance.options('invalid');
         }).toThrow(TypeError);
         expect(() => {
-          mockYargsInstance.options('invalid' as unknown);
+          mockYargsInstance.options('invalid');
         }).toThrow('Options expects options object argument');
       });
     });
@@ -167,10 +167,10 @@ describe('yargsHelper', () => {
 
       test('throws error for non-number argument', () => {
         expect(() => {
-          mockYargsInstance.exit('invalid' as unknown);
+          mockYargsInstance.exit('invalid');
         }).toThrow(TypeError);
         expect(() => {
-          mockYargsInstance.exit('invalid' as unknown);
+          mockYargsInstance.exit('invalid');
         }).toThrow('Exit expects number argument');
       });
     });

--- a/src/tests/implementations/slack/slackClientImpl.test.ts
+++ b/src/tests/implementations/slack/slackClientImpl.test.ts
@@ -195,7 +195,7 @@ describe('SlackClientImpl', () => {
       
       // Set up the mock to reject with an error for this test only
       const error = new Error('Slack API error');
-      mockPostMessage.mockRejectedValueOnce(error as never);
+      mockPostMessage.mockRejectedValueOnce(error);
       
       // Act & Assert
       await expect(slackClient.sendMessage(payload)).rejects.toThrow(

--- a/src/tests/implementations/slack/slackOutputServiceImpl.test.ts
+++ b/src/tests/implementations/slack/slackOutputServiceImpl.test.ts
@@ -54,7 +54,7 @@ describe('SlackOutputServiceImpl', () => {
     
     mockSlackClient = {
       sendMessage: jest.fn<() => Promise<void>>().mockResolvedValue()
-    } as jest.Mocked<SlackClient>;
+    };
     
     mockConfigService = {
       getDate: jest.fn().mockReturnValue(new Date('2022-12-28')),

--- a/src/tests/implementations/slack/slackShowFormatterImpl.test.ts
+++ b/src/tests/implementations/slack/slackShowFormatterImpl.test.ts
@@ -405,7 +405,7 @@ describe('SlackShowFormatterImpl', () => {
   describe('formatMultipleEpisodes edge cases', () => {
     it('should handle null or undefined shows array', () => {
       // Act with null
-      const resultNull = formatter.formatMultipleEpisodes(null as unknown as Show[]);
+      const resultNull = formatter.formatMultipleEpisodes(null);
       
       // Assert
       expect(resultNull).toHaveLength(1);
@@ -414,7 +414,7 @@ describe('SlackShowFormatterImpl', () => {
       expect(sectionBlockNull.text.text).toBe(NO_EPISODES_FOUND);
       
       // Act with undefined
-      const resultUndefined = formatter.formatMultipleEpisodes(undefined as unknown as Show[]);
+      const resultUndefined = formatter.formatMultipleEpisodes();
       
       // Assert
       expect(resultUndefined).toHaveLength(1);

--- a/src/tests/implementations/test/mockLoggerServiceImpl.test.ts
+++ b/src/tests/implementations/test/mockLoggerServiceImpl.test.ts
@@ -149,7 +149,7 @@ describe('MockLoggerServiceImpl', () => {
     });
 
     it('should handle undefined message in context call', () => {
-      mockLogger.info({ context: 'test' }, undefined as unknown as string);
+      mockLogger.info({ context: 'test' });
       
       expect(mockLogger.calls).toHaveLength(1);
       expect(mockLogger.calls[0].message).toBe('');

--- a/src/tests/implementations/text/textOutputServiceImpl.test.ts
+++ b/src/tests/implementations/text/textOutputServiceImpl.test.ts
@@ -61,11 +61,11 @@ describe('TextOutputServiceImpl', () => {
     
     // Create mock output
     mockOutput = {
-      log: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
-      logWithLevel: jest.fn()
-    } as unknown as ProcessOutput;
+      log: jest.fn<ProcessOutput['log']>(),
+      error: jest.fn<ProcessOutput['error']>(),
+      warn: jest.fn<ProcessOutput['warn']>(),
+      logWithLevel: jest.fn<ProcessOutput['logWithLevel']>()
+    };
     
     // Create sample shows for testing
     sampleShows = [

--- a/src/tests/interfaces/httpClient.test.ts
+++ b/src/tests/interfaces/httpClient.test.ts
@@ -2,7 +2,7 @@ import { afterEach, afterAll, beforeEach, describe, expect, it } from '@jest/glo
 import nock from 'nock';
 
 import { FetchHttpClientImpl } from '../../implementations/fetchHttpClientImpl.js';
-import type { HttpClientOptions, HttpClient } from '../../interfaces/httpClient.js';
+import type { HttpClient } from '../../interfaces/httpClient.js';
 
 // Base URL for tests
 const BASE_URL = 'https://api.example.com';
@@ -20,7 +20,7 @@ describe('HttpClient Interface', () => {
   
   beforeEach(() => {
     // Create a new client instance before each test
-    client = new FetchHttpClientImpl({ baseUrl: BASE_URL } as HttpClientOptions);
+    client = new FetchHttpClientImpl({ baseUrl: BASE_URL });
     
     // Disable real network connections
     nock.disableNetConnect();

--- a/src/tests/mocks/factories/configServiceFactory.ts
+++ b/src/tests/mocks/factories/configServiceFactory.ts
@@ -47,7 +47,7 @@ export function createMockConfigService(options: ConfigServiceOptions = {}): Tes
     slack: {
       ...defaultSlackConfig,
       ...appConfig.slack
-    } as SlackConfig
+    }
   };
   
   // Apply slackConfig if provided
@@ -70,7 +70,7 @@ export function createMockConfigService(options: ConfigServiceOptions = {}): Tes
     {
       ...defaultSlackConfig,
       ...options.slackConfig
-    } as SlackConfig
+    }
   );
   
   // By default, enhance with Jest mocks unless explicitly disabled

--- a/src/tests/mocks/factories/formatterFactory.test.ts
+++ b/src/tests/mocks/factories/formatterFactory.test.ts
@@ -23,7 +23,7 @@ describe('FormatterFactory', () => {
 
     const sampleNetworkGroups: NetworkGroups = {
       'Test Network': [sampleShow],
-      'Another Network': [{ ...sampleShow, id: 2, name: 'Another Show' } as Show]
+      'Another Network': [{ ...sampleShow, id: 2, name: 'Another Show' }]
     };
 
     it('should create a mock formatter with default implementations', () => {
@@ -89,9 +89,9 @@ describe('FormatterFactory', () => {
 
       // Assert
       expect(formatter.formatTimedShow(sampleShow)).toBe('Special Format for Show ID 1');
-      const show2 = { ...sampleShow, id: 2 } as Show;
+      const show2 = { ...sampleShow, id: 2 };
       expect(formatter.formatTimedShow(show2)).toBe('Special Format for Show ID 2');
-      const show3 = { ...sampleShow, id: 3 } as Show;
+      const show3 = { ...sampleShow, id: 3 };
       expect(formatter.formatTimedShow(show3)).toBe('Timed Show: Test Show at 20:00');
     });
 

--- a/src/tests/mocks/factories/tvShowServiceFactory.test.ts
+++ b/src/tests/mocks/factories/tvShowServiceFactory.test.ts
@@ -66,7 +66,7 @@ describe('TvShowServiceFactory', () => {
       const service = createMockTvShowService({ defaultShows });
       
       // Act
-      const result = await service.fetchShows({} as ShowOptions);
+      const result = await service.fetchShows({});
       
       // Assert
       expect(result).toEqual(defaultShows);
@@ -83,7 +83,7 @@ describe('TvShowServiceFactory', () => {
       });
       
       // Act
-      const result = await service.fetchShows({ date: TEST_DATE } as ShowOptions);
+      const result = await service.fetchShows({ date: TEST_DATE });
       
       // Assert
       expect(result).toEqual(dateShows);
@@ -100,7 +100,7 @@ describe('TvShowServiceFactory', () => {
       });
       
       // Act
-      const result = await service.fetchShows({ country: 'US' } as ShowOptions);
+      const result = await service.fetchShows({ country: 'US' });
       
       // Assert
       expect(result).toEqual(countryShows);
@@ -117,7 +117,7 @@ describe('TvShowServiceFactory', () => {
       });
       
       // Act
-      const result = await service.fetchShows({ networks: ['Test Network'] } as ShowOptions);
+      const result = await service.fetchShows({ networks: ['Test Network'] });
       
       // Assert
       expect(result).toEqual(networkShows);
@@ -134,7 +134,7 @@ describe('TvShowServiceFactory', () => {
       });
       
       // Act
-      const result = await service.fetchShows({ genres: ['Drama'] } as ShowOptions);
+      const result = await service.fetchShows({ genres: ['Drama'] });
       
       // Assert
       expect(result).toEqual(genreShows);
@@ -151,7 +151,7 @@ describe('TvShowServiceFactory', () => {
       });
       
       // Act
-      const result = await service.fetchShows({ languages: ['English'] } as ShowOptions);
+      const result = await service.fetchShows({ languages: ['English'] });
       
       // Assert
       expect(result).toEqual(languageShows);
@@ -165,7 +165,7 @@ describe('TvShowServiceFactory', () => {
       });
       
       // Act & Assert
-      await expect(service.fetchShows({} as ShowOptions)).rejects.toThrow(error);
+      await expect(service.fetchShows({})).rejects.toThrow(error);
     });
     
     it('should apply custom implementation methods', async () => {

--- a/src/tests/schemas/tvmaze.transform.test.ts
+++ b/src/tests/schemas/tvmaze.transform.test.ts
@@ -5,8 +5,6 @@ import {
   networkScheduleToShowSchema,
   webScheduleToShowSchema
 } from '../../schemas/tvmaze.js';
-import type { Show } from '../../schemas/domain.js';
-
 const EPISODE_TITLE = 'Episode Title';
 const COUNTRY_US = 'United States';
 const NY_TIMEZONE = 'America/New_York';
@@ -59,7 +57,7 @@ describe('TVMaze Schema Transformations', () => {
         airtime: '20:00',
         season: 5,
         number: 10
-      } as Show);
+      });
     });
 
     it('should handle missing or null values with defaults', () => {
@@ -87,7 +85,7 @@ describe('TVMaze Schema Transformations', () => {
         airtime: null,
         season: 0,
         number: 0
-      } as Show);
+      });
     });
 
     it('should handle web channel instead of network', () => {
@@ -172,7 +170,7 @@ describe('TVMaze Schema Transformations', () => {
         airtime: '20:00',
         season: 5,
         number: 10
-      } as Show);
+      });
     });
 
     it('should handle missing or null values with defaults', () => {
@@ -201,7 +199,7 @@ describe('TVMaze Schema Transformations', () => {
         airtime: null,
         season: 0,
         number: 0
-      } as Show);
+      });
     });
   });
 });

--- a/src/tests/schemas/tvmaze.transform.test.ts
+++ b/src/tests/schemas/tvmaze.transform.test.ts
@@ -5,6 +5,7 @@ import {
   networkScheduleToShowSchema,
   webScheduleToShowSchema
 } from '../../schemas/tvmaze.js';
+
 const EPISODE_TITLE = 'Episode Title';
 const COUNTRY_US = 'United States';
 const NY_TIMEZONE = 'America/New_York';

--- a/src/tests/testutils/mockHttpClient.ts
+++ b/src/tests/testutils/mockHttpClient.ts
@@ -44,7 +44,7 @@ export class MockHttpClient implements HttpClient {
    * @param response The response to return
    */
   mockGet<T>(url: string, response: HttpResponse<T>): void {
-    this.mockResponses.set(url, response as HttpResponse<unknown>);
+    this.mockResponses.set(url, response);
     this.getMock.mockResolvedValue(response);
   }
 
@@ -84,7 +84,7 @@ export class MockHttpClient implements HttpClient {
    */
   setMockResponse<T>(response: HttpResponse<T>): void {
     // This will be used as a default response for any URL
-    this.mockResponses.set('*', response as HttpResponse<unknown>);
+    this.mockResponses.set('*', response);
     this.getMock.mockResolvedValue(response);
     this.postMock.mockResolvedValue(response);
   }

--- a/src/tests/utils/errorHandling.test.ts
+++ b/src/tests/utils/errorHandling.test.ts
@@ -26,11 +26,11 @@ interface ExitMockState {
 function setupExitMock(): ExitMockState {
   const state: ExitMockState = {
     mockProcessOutput: {
-      log: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
-      logWithLevel: jest.fn()
-    } as unknown as ProcessOutput,
+      log: jest.fn<ProcessOutput['log']>(),
+      error: jest.fn<ProcessOutput['error']>(),
+      warn: jest.fn<ProcessOutput['warn']>(),
+      logWithLevel: jest.fn<ProcessOutput['logWithLevel']>()
+    },
     originalExit: process.exit,
     exitCalled: false,
     exitCode: 0
@@ -245,7 +245,7 @@ describe('errorHandling', () => {
         registeredCallback = callback;
         return process;
       };
-      process.on = jest.fn(processOnMock) as unknown as typeof process.on;
+      process.on = jest.fn(processOnMock);
 
       registerGlobalErrorHandler(state.mockProcessOutput);
     });

--- a/src/tests/utils/tvMazeUtils.test.ts
+++ b/src/tests/utils/tvMazeUtils.test.ts
@@ -216,7 +216,7 @@ describe('TVMaze Utils', () => {
       const mixedSchedule = [...networkSchedule, null, ...webSchedule, undefined];
       
       // Act
-      const result = transformSchedule(mixedSchedule as unknown[]);
+      const result = transformSchedule(mixedSchedule);
       
       // Assert
       expect(result).toHaveLength(networkSchedule.length + webSchedule.length);
@@ -261,7 +261,7 @@ describe('TVMaze Utils', () => {
         process.env.NODE_ENV = 'production';
         
         // Act - this should not throw but return null
-        const result = transformScheduleItem(malformedItem as unknown as NetworkScheduleItem);
+        const result = transformScheduleItem(malformedItem);
         
         // Assert - the function returns null when an error occurs
         expect(result).toBeNull();


### PR DESCRIPTION
## Summary

- Regenerate lockfile to pick up latest minor/patch versions (`@typescript-eslint/*` 8.59.0, `aws-cdk` 2.1118.4, `aws-cdk-lib` 2.250.0, `eslint` 10.2.1, `eslint-plugin-sonarjs` 4.0.3, `ky` 2.0.1, `nock` 14.0.13, `typescript` 6.0.3)
- Update `@slack/web-api` 7.15.0 → 7.15.1 (pinned version in package.json)
- Fix 44 lint violations from updated `@typescript-eslint` rules: remove unnecessary type assertions, unused imports, and add explicit mock types for `strict-void-return` compliance

## Test plan

- [x] `npm run ci` passes (lint + typecheck + 662 tests)
- [x] `npm start` runs CLI successfully
- [x] `npm outdated` shows no remaining updates